### PR TITLE
Enable build with universal ctags support.

### DIFF
--- a/debian/NEWS
+++ b/debian/NEWS
@@ -1,3 +1,7 @@
+global (6.6.3-3) unstable; urgency=medium
+
+  Enable build with universal ctags.
+
 global (6.5.7-2) unstable; urgency=medium
 
   Starting from 6.5.7-2, global data files that were previously placed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+global (6.6.3-3) unstable; urgency=medium
+
+  * Enable build with universal ctags
+
 global (6.6.3-2) unstable; urgency=medium
 
   * Update standards version to 4.3.0

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,9 @@ override_dh_autoreconf:
 	dh_autoreconf sh reconf.sh
 
 override_dh_auto_configure:
-	dh_auto_configure -- --with-exuberant-ctags=/usr/bin/ctags --disable-static 	\
+	dh_auto_configure -- --with-exuberant-ctags=/usr/bin/ctags-excuberant  \
+		--with-universal-ctags=/usr/bin/ctags-universal  \
+		--disable-static 	\
 		--datadir=/usr/share/$(DEB_SOURCE)
 
 override_dh_auto_install:


### PR DESCRIPTION
The following issue is fixed:

   * What exactly did you do (or not do) that was effective (or
     ineffective)?

cd /etc
cp /usr/share/doc/global/examples/gtags.conf.gz .
gzip -d gtags.conf.gz
export GTAGSLABEL=new-ctags
gtags

   * What was the outcome of this action?

gtags: Universal Ctags not found. Please see ./configure --help.

   * What outcome did you expect instead?

Current dir is tagged.
